### PR TITLE
Specify bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
         build-essential \
         git \
         nodejs \
-    && gem install bundler \
+    && gem install bundler -v 2.4.22\
     && bundle install \
     && apt-get remove -y build-essential git \
     && apt-get autoremove -y \


### PR DESCRIPTION
To fix `docker build`

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->